### PR TITLE
Fix no passphrase error

### DIFF
--- a/pkcsutil.py
+++ b/pkcsutil.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='pkcsutil converts a PEM formatted certificate/private key to PKCS12.')
     parser.add_argument('--key',  help='Private key filename, PEM encoded.')
     parser.add_argument('--cert', help='Certificate filename, PEM encoded.')
-    parser.add_argument('--passphrase', help='Passphrase for the private key.', default="")
+    parser.add_argument('--passphrase', help='Passphrase for the private key.', default='')
     parser.add_argument('--out',  help='Output filename (.pfx).')
 
     args = parser.parse_args()

--- a/pkcsutil.py
+++ b/pkcsutil.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='pkcsutil converts a PEM formatted certificate/private key to PKCS12.')
     parser.add_argument('--key',  help='Private key filename, PEM encoded.')
     parser.add_argument('--cert', help='Certificate filename, PEM encoded.')
-    parser.add_argument('--passphrase', help='Passphrase for the private key.', default=None)
+    parser.add_argument('--passphrase', help='Passphrase for the private key.', default="")
     parser.add_argument('--out',  help='Output filename (.pfx).')
 
     args = parser.parse_args()


### PR DESCRIPTION
When not giving a passphrase, like 59 bails out because None doesn't have a length:

```
Traceback (most recent call last):
  File "pkcsutil.py", line 59, in <module>
    if len(passphrase) == 0:
TypeError: object of type 'NoneType' has no len()
```

Setting the default to empty string fixes that.